### PR TITLE
Fix indentation in readme TOC

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # Tools and Methodologies
 
 * [Methodologies](./methodologies)
- * [Investigating a memory leak](./methodologies/investigating-memory-leak.md).
- * [Investigating a crash](./methodologies/investigating-crash.md)
- * [Investigating a performance problem](./methodologies/investigating-performance.md)
- * [Investigating a third-party module problem](./methodologies/investigating-third-party-module.md)
+  * [Investigating a memory leak](./methodologies/investigating-memory-leak.md).
+  * [Investigating a crash](./methodologies/investigating-crash.md)
+  * [Investigating a performance problem](./methodologies/investigating-performance.md)
+  * [Investigating a third-party module problem](./methodologies/investigating-third-party-module.md)
 * [Debugging tools](./debugging-tools)


### PR DESCRIPTION
This fixes rendering at least on GH, possibly with other renderers as well.